### PR TITLE
Fixed boost::thread_resource_error: Resource temporarily unavailable …

### DIFF
--- a/src/rx.cpp
+++ b/src/rx.cpp
@@ -235,5 +235,6 @@ void rx_stop_all()
 
 void rx_thread_start(ros::NodeHandle& n, int fd, std::string frame_id, uint32_t byte_time_ns)
 {
+  rx_prune_threads();
   rx_threads.push_back(new boost::thread(_thread_func, boost::ref(n), fd, frame_id, byte_time_ns));
 }

--- a/src/socket_node.cpp
+++ b/src/socket_node.cpp
@@ -129,6 +129,8 @@ int main(int argc, char **argv)
     }
   }
 
+  rx_stop_all();
+
   close(listener_fd);
   return 0;
 }


### PR DESCRIPTION
issue #4: Exception that was thrown using netcat to feed socket_node.cpp with NMEA sentences.